### PR TITLE
fix(grok): 优化流式响应数据解析逻辑

### DIFF
--- a/src/grok_search/providers/grok.py
+++ b/src/grok_search/providers/grok.py
@@ -102,10 +102,12 @@ class GrokSearchProvider(BaseSearchProvider):
                     continue
                 try:
                     data = json.loads(line[6:])
-                    delta = data.get("choices", [{}])[0].get("delta", {})
-                    if "content" in delta:
-                        content += delta["content"]
-                except json.JSONDecodeError:
+                    choices = data.get("choices", [])
+                    if choices and len(choices) > 0:
+                        delta = choices[0].get("delta", {})
+                        if "content" in delta:
+                            content += delta["content"]
+                except (json.JSONDecodeError, IndexError):
                     continue
         
         # 非流式 JSON 兜底处理


### PR DESCRIPTION
- 针对修复 Error: Error calling tool 'web_search': list index out of range 的问题
- 修复了当 choices 数组为空时可能出现的 IndexError 异常
- 添加了对 choices 数组长度的检查以避免索引越界
- 改进了 JSON 解析错误的异常处理机制
- 确保在异常情况下能够正确执行兜底处理逻辑

在使用 web_search 工具时，当 API 返回空的 choices 数组时会触发 IndexError: list index out of range 错误，导致搜索功能崩溃。

  错误信息：
  Error calling tool 'web_search': list index out of range

  触发场景：
  - API 限流或配额耗尽返回空响应
  - 网络异常导致部分数据丢失
  - API 内部错误但返回 200 状态码
  - 流式响应中的某些中间帧为空

  解决方案 (Solution)

  修改 src/grok_search/providers/grok.py 中的 _parse_streaming_response 方法，在访问数组索引前添加显式的长度检查。

  核心改动：

  # 修改前（有问题）
  delta = data.get("choices", [{}])[0].get("delta", {})

  # 修改后（安全）
  choices = data.get("choices", [])
  if choices and len(choices) > 0:
      delta = choices[0].get("delta", {})
      if "content" in delta:
          content += delta["content"]

  技术细节 (Technical Details)

  1. 分离获取和访问：先获取 choices 数组，再检查是否为空
  2. 双重验证：使用 choices and len(choices) > 0 确保数组非空
  3. 异常处理增强：捕获 IndexError 和 json.JSONDecodeError 两种异常
  4. 降级：空响应时静默跳过，不影响后续处理

  测试验证 (Testing)

  - ✅ 正常响应：功能正常工作
  - ✅ 空 choices 数组：不再崩溃，选择跳过
  - ✅ choices 不存在：使用默认值，正常处理
