### PR TITLE
feat: 自动注入本地时间到搜索查询

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ claude mcp list
 
 #### MCP 工具说明
 
-本项目提供六个 MCP 工具：
+本项目提供五个 MCP 工具：
 
 ##### `web_search` - 网络搜索
 
@@ -355,35 +355,6 @@ Model Context Protocol (MCP) 是一个标准化的通信协议，用于连接 AI
     "message": "成功获取模型列表 (HTTP 200)，共 x 个模型",
     "response_time_ms": 234.56
   }
-}
-```
-
-</details>
-
-##### `get_current_time` - 获取当前时间
-
-**无需参数**。返回系统本地时间信息，确保时间相关查询的准确性。
-
-**功能**：
-- 获取准确的本地日期和时间
-- 自动检测系统时区
-- 支持中英文星期显示
-- 提供多种时间格式（ISO 8601、Unix 时间戳等）
-
-**注意**：`web_search` 工具会**自动注入当前时间信息**到搜索查询中，因此大多数情况下无需手动调用此工具。
-
-<details>
-<summary><b>返回示例</b>（点击展开）</summary>
-
-```json
-{
-  "date": "2024-01-15",
-  "time": "14:30:25",
-  "weekday": "星期一",
-  "weekday_en": "Monday",
-  "timezone": "CST",
-  "iso_format": "2024-01-15T14:30:25+08:00",
-  "unix_timestamp": 1705300225
 }
 ```
 

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -257,7 +257,7 @@ Module Description:
 
 #### MCP Tools
 
-This project provides six MCP tools:
+This project provides five MCP tools:
 
 ##### `web_search` - Web Search
 
@@ -382,37 +382,6 @@ For more information, visit [Official Documentation](https://modelcontextprotoco
     "message": "Successfully retrieved model list (HTTP 200), 5 models available",
     "response_time_ms": 234.56
   }
-}
-```
-
-</details>
-
-##### `get_current_time` - Get Current Time
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| None | - | - | This tool requires no parameters |
-
-**Features**:
-- Get accurate local date and time
-- Auto-detect system timezone
-- Support Chinese and English weekday display
-- Provide multiple time formats (ISO 8601, Unix timestamp, etc.)
-
-**Note**: The `web_search` tool **automatically injects current time information** into search queries, so in most cases you don't need to call this tool manually.
-
-<details>
-<summary><b>Return Example</b> (Click to expand)</summary>
-
-```json
-{
-  "date": "2024-01-15",
-  "time": "14:30:25",
-  "weekday": "星期一",
-  "weekday_en": "Monday",
-  "timezone": "CST",
-  "iso_format": "2024-01-15T14:30:25+08:00",
-  "unix_timestamp": 1705300225
 }
 ```
 

--- a/src/grok_search/server.py
+++ b/src/grok_search/server.py
@@ -10,13 +10,13 @@ from fastmcp import FastMCP, Context
 
 # 尝试使用绝对导入（支持 mcp run）
 try:
-    from grok_search.providers.grok import GrokSearchProvider, get_local_time_info
+    from grok_search.providers.grok import GrokSearchProvider
     from grok_search.utils import format_search_results
     from grok_search.logger import log_info
     from grok_search.config import config
 except ImportError:
     # 降级到相对导入（pip install -e . 后）
-    from .providers.grok import GrokSearchProvider, get_local_time_info
+    from .providers.grok import GrokSearchProvider
     from .utils import format_search_results
     from .logger import log_info
     from .config import config
@@ -230,62 +230,6 @@ async def get_config_info() -> str:
     config_info["connection_test"] = test_result
 
     return json.dumps(config_info, ensure_ascii=False, indent=2)
-
-
-@mcp.tool(
-    name="get_current_time",
-    description="""
-    Returns the current local time from the system.
-
-    This tool is useful for:
-    - Getting accurate current date and time for time-sensitive queries
-    - Understanding the user's local timezone
-    - Providing time context for search queries that involve "today", "this week", "recent", etc.
-
-    Returns
-    -------
-    str
-        A JSON-encoded string containing:
-        - `date`: Current date in YYYY-MM-DD format
-        - `time`: Current time in HH:MM:SS format
-        - `weekday`: Day of the week in Chinese
-        - `weekday_en`: Day of the week in English
-        - `timezone`: Local timezone name
-        - `iso_format`: Full ISO 8601 timestamp
-        - `unix_timestamp`: Unix timestamp (seconds since epoch)
-
-    Notes
-    -----
-    - Time is obtained from the local system, not from the AI model
-    - This ensures accurate time information regardless of model's knowledge cutoff
-    - Useful for queries involving relative time expressions
-    """
-)
-async def get_current_time() -> str:
-    import json
-    from datetime import datetime, timezone
-
-    try:
-        # 获取本地时区
-        local_tz = datetime.now().astimezone().tzinfo
-        local_now = datetime.now(local_tz)
-    except Exception:
-        local_now = datetime.now(timezone.utc)
-
-    weekdays_cn = ["星期一", "星期二", "星期三", "星期四", "星期五", "星期六", "星期日"]
-    weekdays_en = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
-
-    time_info = {
-        "date": local_now.strftime("%Y-%m-%d"),
-        "time": local_now.strftime("%H:%M:%S"),
-        "weekday": weekdays_cn[local_now.weekday()],
-        "weekday_en": weekdays_en[local_now.weekday()],
-        "timezone": local_now.tzname() or "Local",
-        "iso_format": local_now.isoformat(),
-        "unix_timestamp": int(local_now.timestamp())
-    }
-
-    return json.dumps(time_info, ensure_ascii=False, indent=2)
 
 
 @mcp.tool(


### PR DESCRIPTION
## Summary
- 添加 `get_local_time_info()` 函数，用于获取系统本地时间
- 在搜索查询中自动注入当前时间上下文
- 新增 MCP 工具 `get_current_time`，支持显式获取时间
- 时间从本地系统获取，而非依赖模型的知识截止日期
- 支持中英文星期显示、多种时间格式（ISO 8601、Unix 时间戳等）

## 解决的问题
当用户搜索如"今天的新闻"、"最新动态"等时间相关查询时，Grok 模型可能不知道准确的当前时间（因为模型有知识截止日期）。此 PR 通过在搜索时自动注入本地时间信息，确保时间敏感的搜索能够正确工作。

## 修改内容
- `src/grok_search/providers/grok.py`: 添加 `get_local_time_info()` 函数，在搜索时自动注入时间
- `src/grok_search/server.py`: 新增 `get_current_time` MCP 工具
- `README.md` / `docs/README_EN.md`: 更新文档，添加新功能说明

## Test plan
- [ ] 测试 `web_search` 工具，验证时间上下文是否正确注入
- [ ] 测试 `get_current_time` 工具，验证返回格式正确
- [ ] 验证不同时区下时间获取是否正确