### PR TITLE
fix: 兼容无空格的 SSE 格式 (data:{...})

### DIFF
--- a/src/grok_search/providers/grok.py
+++ b/src/grok_search/providers/grok.py
@@ -124,11 +124,14 @@ class GrokSearchProvider(BaseSearchProvider):
             
             full_body_buffer.append(line)
 
-            if line.startswith("data: "):
-                if line == "data: [DONE]":
+            # 兼容 "data: {...}" 和 "data:{...}" 两种 SSE 格式
+            if line.startswith("data:"):
+                if line in ("data: [DONE]", "data:[DONE]"):
                     continue
                 try:
-                    data = json.loads(line[6:])
+                    # 去掉 "data:" 前缀，并去除可能的空格
+                    json_str = line[5:].lstrip()
+                    data = json.loads(json_str)
                     choices = data.get("choices", [])
                     if choices and len(choices) > 0:
                         delta = choices[0].get("delta", {})


### PR DESCRIPTION
某些 API 代理（如 AxonHub）返回的 SSE 格式是 "data:{...}" 而不是标准的 "data: {...}"。 此修复使解析器同时兼容两种格式。