### PR TITLE
feat: 多平台支持与 OpenRouter 自动补全 :online 后缀

### DIFF
--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -49,6 +49,8 @@ Comparison with other search solutions:
 - ✅ Dynamic model switching (switch between Grok models with persistent settings)
 - ✅ **Tool routing control (one-click disable built-in WebSearch/WebFetch, force use GrokSearch)**
 - ✅ **Automatic time injection (automatically gets local time during search for accurate time-sensitive queries)**
+- ✅ **Multi-platform support (auto-detect xAI Official / OpenRouter / Generic OpenAI-compatible)**
+- ✅ **OpenRouter auto-appends `:online` suffix, no manual configuration needed**
 - ✅ Extensible architecture for additional search providers
 
 ## Quick Start
@@ -101,20 +103,23 @@ claude mcp add-json grok-search --scope user '{
     "grok-search"
   ],
   "env": {
-    "GROK_API_URL": "https://your-api-endpoint.com/v1",
-    "GROK_API_KEY": "your-api-key-here"
+    "GROK_API_URL": "https://openrouter.ai/api/v1",
+    "GROK_API_KEY": "your-api-key-here",
+    "GROK_MODEL": "x-ai/grok-4-fast"
   }
 }'
 ```
 
 #### Configuration Guide
 
-Configuration is done through **environment variables**, set directly in the `env` field during installation:
+Configuration is done through **environment variables**, set directly in the `env` field during installation. OpenRouter users don't need to manually add the `:online` suffix - it's automatically appended:
 
 | Environment Variable | Required | Default | Description |
 |---------------------|----------|---------|-------------|
-| `GROK_API_URL` | ✅ | - | Grok API endpoint (OpenAI-compatible format) |
+| `GROK_API_URL` | ✅ | - | API endpoint URL |
 | `GROK_API_KEY` | ✅ | - | Your API Key |
+| `GROK_MODEL` | ❌ | `grok-4-fast` | Model ID (`:online` suffix auto-appended for OpenRouter) |
+| `GROK_PROVIDER` | ❌ | Auto-detect | Manually specify platform: `xai` / `openrouter` / `generic` |
 | `GROK_DEBUG` | ❌ | `false` | Enable debug mode (`true`/`false`) |
 | `GROK_LOG_LEVEL` | ❌ | `INFO` | Log level (DEBUG/INFO/WARNING/ERROR) |
 | `GROK_LOG_DIR` | ❌ | `logs` | Log file storage directory |
@@ -172,6 +177,39 @@ If you see `❌ 连接失败` or `⚠️ 连接异常`, please check:
 - API URL is correct
 - API Key is valid
 - Network connection is working
+
+### Multi-Platform Support
+
+Grok Search MCP supports multiple API platforms with automatic detection based on `GROK_API_URL`:
+
+| Platform | URL Pattern | Search Capability | Example |
+|----------|------------|-------------------|---------|
+| **OpenRouter** | `openrouter.ai` | ✅ Native real-time search (`:online` auto-appended) | `GROK_MODEL=x-ai/grok-4-fast` |
+| **xAI Official** | `api.x.ai` | ✅ Native real-time search (planned) | `GROK_MODEL=grok-4-fast` |
+| **Generic** | Other URLs | ⚠️ Prompt-based search | `GROK_MODEL=grok-4-fast` |
+
+#### OpenRouter Users (Recommended)
+
+When using OpenRouter, the system **automatically appends the `:online` suffix** to the model name to enable native real-time web search - no manual configuration needed:
+
+```bash
+claude mcp add-json grok-search --scope user '{
+  "type": "stdio",
+  "command": "uvx",
+  "args": [
+    "--from",
+    "git+https://github.com/GuDaStudio/GrokSearch",
+    "grok-search"
+  ],
+  "env": {
+    "GROK_API_URL": "https://openrouter.ai/api/v1",
+    "GROK_API_KEY": "sk-or-v1-xxx",
+    "GROK_MODEL": "x-ai/grok-4-fast"
+  }
+}'
+```
+
+> **💡 Tip**: When OpenRouter is detected, the system automatically appends `:online` to the model name (e.g., `x-ai/grok-4-fast` → `x-ai/grok-4-fast:online`), enabling xAI's native Web Search + X Search capabilities. Search results include real source citations.
 
 ###  4. Advanced Configuration (Optional)
 To better utilize Grok Search, you can optimize the overall Vibe Coding CLI by configuring Claude Code or similar system prompts. For Claude Code, edit ~/.claude/CLAUDE.md with the following content:
@@ -491,6 +529,15 @@ A: Register with a third-party platform → Obtain API Endpoint and Key → Conf
 
 **Q: How to verify configuration after setup?**
 A: Say "Show grok-search configuration info" in Claude conversation to check connection test results
+
+**Q: Search results are inaccurate when using OpenRouter?**
+A: The system automatically appends the `:online` suffix for OpenRouter models to enable real-time search. If issues persist, use the `get_config_info` tool to verify the actual model name includes `:online`.
+
+**Q: Which API platforms are supported?**
+A: All OpenAI-compatible API platforms are supported. OpenRouter (with automatic native search) or xAI Official API are recommended. The platform type is auto-detected from `GROK_API_URL`.
+
+**Q: What is the `:online` suffix?**
+A: It's an OpenRouter-specific model variant suffix that enables real-time web search. For xAI models, it enables both Web Search and X (Twitter) Search. When using OpenRouter, this suffix is automatically appended - no manual configuration needed.
 
 ## License
 

--- a/src/grok_search/config.py
+++ b/src/grok_search/config.py
@@ -2,15 +2,18 @@ import os
 import json
 from pathlib import Path
 
+
 class Config:
     _instance = None
     _SETUP_COMMAND = (
-        'claude mcp add-json grok-search --scope user '
+        "claude mcp add-json grok-search --scope user "
         '\'{"type":"stdio","command":"uvx","args":["--from",'
         '"git+https://github.com/GuDaStudio/GrokSearch","grok-search"],'
         '"env":{"GROK_API_URL":"your-api-url","GROK_API_KEY":"your-api-key"}}\''
     )
     _DEFAULT_MODEL = "grok-4-fast"
+    _ONLINE_PROVIDERS = ("openrouter.ai",)
+    _XAI_PROVIDERS = ("api.x.ai",)
 
     def __new__(cls):
         if cls._instance is None:
@@ -31,14 +34,14 @@ class Config:
         if not self.config_file.exists():
             return {}
         try:
-            with open(self.config_file, 'r', encoding='utf-8') as f:
+            with open(self.config_file, "r", encoding="utf-8") as f:
                 return json.load(f)
         except (json.JSONDecodeError, IOError):
             return {}
 
     def _save_config_file(self, config_data: dict) -> None:
         try:
-            with open(self.config_file, 'w', encoding='utf-8') as f:
+            with open(self.config_file, "w", encoding="utf-8") as f:
                 json.dump(config_data, f, ensure_ascii=False, indent=2)
         except IOError as e:
             raise ValueError(f"无法保存配置文件: {str(e)}")
@@ -102,23 +105,53 @@ class Config:
 
     @property
     def grok_model(self) -> str:
-        if self._cached_model is not None:
-            return self._cached_model
+        # 优先级：环境变量 > 配置文件 > 默认值
+        env_model = os.getenv("GROK_MODEL")
+        if env_model:
+            model = env_model
+        elif self._cached_model is not None:
+            model = self._cached_model
+        else:
+            config_data = self._load_config_file()
+            file_model = config_data.get("model")
+            if file_model:
+                self._cached_model = file_model
+                model = file_model
+            else:
+                self._cached_model = self._DEFAULT_MODEL
+                model = self._DEFAULT_MODEL
 
-        config_data = self._load_config_file()
-        file_model = config_data.get("model")
-        if file_model:
-            self._cached_model = file_model
-            return file_model
+        # OpenRouter 需要 :online 后缀才能启用联网搜索，自动补全
+        if self.provider_type == "openrouter" and ":online" not in model:
+            model = f"{model}:online"
 
-        self._cached_model = self._DEFAULT_MODEL
-        return self._DEFAULT_MODEL
+        return model
 
     def set_model(self, model: str) -> None:
         config_data = self._load_config_file()
         config_data["model"] = model
         self._save_config_file(config_data)
         self._cached_model = model
+
+    @property
+    def provider_type(self) -> str:
+        """检测当前使用的 provider 类型: 'xai', 'openrouter', 'generic'"""
+        override = os.getenv("GROK_PROVIDER", "").lower().strip()
+        if override in ("xai", "openrouter", "generic"):
+            return override
+
+        try:
+            url = self.grok_api_url.lower()
+        except ValueError:
+            return "generic"
+
+        for domain in self._XAI_PROVIDERS:
+            if domain in url:
+                return "xai"
+        for domain in self._ONLINE_PROVIDERS:
+            if domain in url:
+                return "openrouter"
+        return "generic"
 
     @staticmethod
     def _mask_api_key(key: str) -> str:
@@ -143,12 +176,16 @@ class Config:
             "GROK_API_URL": api_url,
             "GROK_API_KEY": api_key_masked,
             "GROK_MODEL": self.grok_model,
+            "GROK_PROVIDER": self.provider_type,
             "GROK_DEBUG": self.debug_enabled,
             "GROK_LOG_LEVEL": self.log_level,
             "GROK_LOG_DIR": str(self.log_dir),
             "TAVILY_ENABLED": self.tavily_enabled,
-            "TAVILY_API_KEY": self._mask_api_key(self.tavily_api_key) if self.tavily_api_key else "未配置",
-            "config_status": config_status
+            "TAVILY_API_KEY": self._mask_api_key(self.tavily_api_key)
+            if self.tavily_api_key
+            else "未配置",
+            "config_status": config_status,
         }
+
 
 config = Config()

--- a/src/grok_search/providers/grok.py
+++ b/src/grok_search/providers/grok.py
@@ -3,11 +3,19 @@ import json
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
 from typing import List, Optional
-from tenacity import AsyncRetrying, retry_if_exception, stop_after_attempt, wait_random_exponential
+from tenacity import (
+    AsyncRetrying,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_random_exponential,
+)
 from tenacity.wait import wait_base
 from zoneinfo import ZoneInfo
 from .base import BaseSearchProvider, SearchResult
-from ..utils import search_prompt, fetch_prompt
+from ..utils import (
+    search_prompt,
+    fetch_prompt,
+)
 from ..logger import log_info
 from ..config import config
 
@@ -38,21 +46,54 @@ def _needs_time_context(query: str) -> bool:
     """检查查询是否需要时间上下文"""
     # 中文时间相关关键词
     cn_keywords = [
-        "当前", "现在", "今天", "明天", "昨天",
-        "本周", "上周", "下周", "这周",
-        "本月", "上月", "下月", "这个月",
-        "今年", "去年", "明年",
-        "最新", "最近", "近期", "刚刚", "刚才",
-        "实时", "即时", "目前",
+        "当前",
+        "现在",
+        "今天",
+        "明天",
+        "昨天",
+        "本周",
+        "上周",
+        "下周",
+        "这周",
+        "本月",
+        "上月",
+        "下月",
+        "这个月",
+        "今年",
+        "去年",
+        "明年",
+        "最新",
+        "最近",
+        "近期",
+        "刚刚",
+        "刚才",
+        "实时",
+        "即时",
+        "目前",
     ]
     # 英文时间相关关键词
     en_keywords = [
-        "current", "now", "today", "tomorrow", "yesterday",
-        "this week", "last week", "next week",
-        "this month", "last month", "next month",
-        "this year", "last year", "next year",
-        "latest", "recent", "recently", "just now",
-        "real-time", "realtime", "up-to-date",
+        "current",
+        "now",
+        "today",
+        "tomorrow",
+        "yesterday",
+        "this week",
+        "last week",
+        "next week",
+        "this month",
+        "last month",
+        "next month",
+        "this year",
+        "last year",
+        "next year",
+        "latest",
+        "recent",
+        "recently",
+        "just now",
+        "real-time",
+        "realtime",
+        "up-to-date",
     ]
 
     query_lower = query.lower()
@@ -67,12 +108,21 @@ def _needs_time_context(query: str) -> bool:
 
     return False
 
+
 RETRYABLE_STATUS_CODES = {408, 429, 500, 502, 503, 504}
 
 
 def _is_retryable_exception(exc) -> bool:
     """检查异常是否可重试"""
-    if isinstance(exc, (httpx.TimeoutException, httpx.NetworkError, httpx.ConnectError, httpx.RemoteProtocolError)):
+    if isinstance(
+        exc,
+        (
+            httpx.TimeoutException,
+            httpx.NetworkError,
+            httpx.ConnectError,
+            httpx.RemoteProtocolError,
+        ),
+    ):
         return True
     if isinstance(exc, httpx.HTTPStatusError):
         return exc.response.status_code in RETRYABLE_STATUS_CODES
@@ -89,7 +139,10 @@ class _WaitWithRetryAfter(wait_base):
     def __call__(self, retry_state):
         if retry_state.outcome and retry_state.outcome.failed:
             exc = retry_state.outcome.exception()
-            if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code == 429:
+            if (
+                isinstance(exc, httpx.HTTPStatusError)
+                and exc.response.status_code == 429
+            ):
                 retry_after = self._parse_retry_after(exc.response)
                 if retry_after is not None:
                     return retry_after
@@ -125,7 +178,14 @@ class GrokSearchProvider(BaseSearchProvider):
     def get_provider_name(self) -> str:
         return "Grok"
 
-    async def search(self, query: str, platform: str = "", min_results: int = 3, max_results: int = 10, ctx=None) -> List[SearchResult]:
+    async def search(
+        self,
+        query: str,
+        platform: str = "",
+        min_results: int = 3,
+        max_results: int = 10,
+        ctx=None,
+    ) -> List[SearchResult]:
         headers = {
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",
@@ -134,12 +194,20 @@ class GrokSearchProvider(BaseSearchProvider):
         return_prompt = ""
 
         if platform:
-            platform_prompt = "\n\nYou should search the web for the information you need, and focus on these platform: " + platform
+            platform_prompt = (
+                "\n\nYou should search the web for the information you need, and focus on these platform: "
+                + platform
+            )
 
         if max_results:
-            return_prompt = "\n\nYou should return the results in a JSON format, and the results should at least be " + str(min_results) + " and at most be " + str(max_results) + " results."
+            return_prompt = (
+                "\n\nYou should return the results in a JSON format, and the results should at least be "
+                + str(min_results)
+                + " and at most be "
+                + str(max_results)
+                + " results."
+            )
 
-        # 仅在查询包含时间相关关键词时注入当前时间信息
         if _needs_time_context(query):
             time_context = get_local_time_info() + "\n"
         else:
@@ -152,12 +220,19 @@ class GrokSearchProvider(BaseSearchProvider):
                     "role": "system",
                     "content": search_prompt,
                 },
-                {"role": "user", "content": time_context + query + platform_prompt + return_prompt },
+                {
+                    "role": "user",
+                    "content": time_context + query + platform_prompt + return_prompt,
+                },
             ],
             "stream": True,
         }
 
-        await log_info(ctx, f"platform_prompt: { query + platform_prompt + return_prompt}", config.debug_enabled)
+        await log_info(
+            ctx,
+            f"platform_prompt: {query + platform_prompt + return_prompt}",
+            config.debug_enabled,
+        )
 
         return await self._execute_stream_with_retry(headers, payload, ctx)
 
@@ -166,6 +241,7 @@ class GrokSearchProvider(BaseSearchProvider):
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",
         }
+
         payload = {
             "model": self.model,
             "messages": [
@@ -173,7 +249,10 @@ class GrokSearchProvider(BaseSearchProvider):
                     "role": "system",
                     "content": fetch_prompt,
                 },
-                {"role": "user", "content": url + "\n获取该网页内容并返回其结构化Markdown格式" },
+                {
+                    "role": "user",
+                    "content": url + "\n获取该网页内容并返回其结构化Markdown格式",
+                },
             ],
             "stream": True,
         }
@@ -181,21 +260,20 @@ class GrokSearchProvider(BaseSearchProvider):
 
     async def _parse_streaming_response(self, response, ctx=None) -> str:
         content = ""
-        full_body_buffer = [] 
-        
+        annotations = []
+        full_body_buffer = []
+
         async for line in response.aiter_lines():
             line = line.strip()
             if not line:
                 continue
-            
+
             full_body_buffer.append(line)
 
-            # 兼容 "data: {...}" 和 "data:{...}" 两种 SSE 格式
             if line.startswith("data:"):
                 if line in ("data: [DONE]", "data:[DONE]"):
                     continue
                 try:
-                    # 去掉 "data:" 前缀，并去除可能的空格
                     json_str = line[5:].lstrip()
                     data = json.loads(json_str)
                     choices = data.get("choices", [])
@@ -203,9 +281,11 @@ class GrokSearchProvider(BaseSearchProvider):
                         delta = choices[0].get("delta", {})
                         if "content" in delta:
                             content += delta["content"]
+                        if "annotations" in delta:
+                            annotations.extend(delta["annotations"])
                 except (json.JSONDecodeError, IndexError):
                     continue
-                
+
         if not content and full_body_buffer:
             try:
                 full_text = "".join(full_body_buffer)
@@ -213,21 +293,50 @@ class GrokSearchProvider(BaseSearchProvider):
                 if "choices" in data and len(data["choices"]) > 0:
                     message = data["choices"][0].get("message", {})
                     content = message.get("content", "")
+                    if "annotations" in message:
+                        annotations.extend(message["annotations"])
             except json.JSONDecodeError:
                 pass
-        
+
+        if annotations:
+            content = self._append_citations(content, annotations)
+
         await log_info(ctx, f"content: {content}", config.debug_enabled)
 
         return content
 
-    async def _execute_stream_with_retry(self, headers: dict, payload: dict, ctx=None) -> str:
+    @staticmethod
+    def _append_citations(content: str, annotations: list) -> str:
+        citations = []
+        for ann in annotations:
+            if ann.get("type") != "url_citation":
+                continue
+            citation = ann.get("url_citation", ann)
+            url = citation.get("url", "")
+            title = citation.get("title", url)
+            if url and url not in [c[1] for c in citations]:
+                citations.append((title, url))
+
+        if not citations:
+            return content
+
+        content += "\n\n---\n**Sources:**\n"
+        for title, url in citations:
+            content += f"- [{title}]({url})\n"
+        return content
+
+    async def _execute_stream_with_retry(
+        self, headers: dict, payload: dict, ctx=None
+    ) -> str:
         """执行带重试机制的流式 HTTP 请求"""
         timeout = httpx.Timeout(connect=6.0, read=120.0, write=10.0, pool=None)
 
         async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
             async for attempt in AsyncRetrying(
                 stop=stop_after_attempt(config.retry_max_attempts + 1),
-                wait=_WaitWithRetryAfter(config.retry_multiplier, config.retry_max_wait),
+                wait=_WaitWithRetryAfter(
+                    config.retry_multiplier, config.retry_max_wait
+                ),
                 retry=retry_if_exception(_is_retryable_exception),
                 reraise=True,
             ):

--- a/src/grok_search/utils.py
+++ b/src/grok_search/utils.py
@@ -9,22 +9,23 @@ def format_search_results(results: List[SearchResult]) -> str:
     formatted = []
     for i, result in enumerate(results, 1):
         parts = [f"## Result {i}: {result.title}"]
-        
+
         if result.url:
             parts.append(f"**URL:** {result.url}")
-        
+
         if result.snippet:
             parts.append(f"**Summary:** {result.snippet}")
-        
+
         if result.source:
             parts.append(f"**Source:** {result.source}")
-        
+
         if result.published_date:
             parts.append(f"**Published:** {result.published_date}")
-        
+
         formatted.append("\n".join(parts))
 
     return "\n\n---\n\n".join(formatted)
+
 
 fetch_prompt = """
 # Profile: Web Content Fetcher


### PR DESCRIPTION
## Summary

- 新增多平台自动检测：根据 `GROK_API_URL` 自动识别 xAI 官方 / OpenRouter / 通用 OpenAI 兼容平台
- 新增 `GROK_MODEL` 环境变量支持（优先级：环境变量 > 配置文件 > 默认值）
- OpenRouter 平台自动补全 `:online` 后缀，用户无需手动配置即可启用原生实时搜索
- 新增 `GROK_PROVIDER` 环境变量，支持手动指定平台类型
- 新增 OpenRouter annotations 解析，搜索结果自动附带来源引用（Sources）

## Changes

### `src/grok_search/config.py`
- `grok_model` 属性：新增 `GROK_MODEL` 环境变量优先级（环境变量 > 配置文件 > 默认值）
- `grok_model` 属性：OpenRouter 平台自动追加 `:online` 后缀（已有则不重复）
- 新增 `provider_type` 属性：根据 URL 自动检测或通过 `GROK_PROVIDER` 手动指定（`xai` / `openrouter` / `generic`）
- `get_config_info()` 输出中增加 `GROK_PROVIDER` 字段

### `src/grok_search/providers/grok.py`
- `_parse_streaming_response()` 新增 annotations 收集逻辑
- 新增 `_append_citations()` 静态方法：将 `url_citation` 类型的 annotations 格式化为 Markdown 引用列表

### `src/grok_search/utils.py`
- 格式化清理（trailing whitespace 等）

### 文档
- `README.md` / `docs/README_EN.md`：新增多平台支持章节、环境变量说明表、OpenRouter 自动补全说明、FAQ

## Test Plan

- [ ] 设置 xAI 环境变量 → `grok_model` 不带 `:online`
- [ ] 设置 OpenRouter 环境变量，model 不带 `:online` → `grok_model` 自动补全为 `model:online`
- [ ] 设置 OpenRouter 环境变量，model 已带 `:online` → 不重复追加
- [ ] 运行 `get_config_info` 工具 → 输出包含 `GROK_PROVIDER` 字段
- [ ] OpenRouter 搜索结果包含 Sources 引用

Closes #13