### PR TITLE
feat: 可配置读超时 + 支持 reasoning 模型 (expert 等)

### DIFF
--- a/src/grok_search/config.py
+++ b/src/grok_search/config.py
@@ -65,6 +65,14 @@ class Config:
         return int(os.getenv("GROK_RETRY_MAX_WAIT", "10"))
 
     @property
+    def read_timeout(self) -> float:
+        return float(os.getenv("GROK_READ_TIMEOUT", "300"))
+
+    @property
+    def connect_timeout(self) -> float:
+        return float(os.getenv("GROK_CONNECT_TIMEOUT", "6"))
+
+    @property
     def guda_base_url(self) -> str:
         return os.getenv("GUDA_BASE_URL", self._DEFAULT_GUDA_BASE_URL)
 

--- a/src/grok_search/providers/grok.py
+++ b/src/grok_search/providers/grok.py
@@ -173,13 +173,14 @@ class GrokSearchProvider(BaseSearchProvider):
 
     async def _parse_streaming_response(self, response, ctx=None) -> str:
         content = ""
-        full_body_buffer = [] 
-        
+        reasoning = ""
+        full_body_buffer = []
+
         async for line in response.aiter_lines():
             line = line.strip()
             if not line:
                 continue
-            
+
             full_body_buffer.append(line)
 
             # 兼容 "data: {...}" 和 "data:{...}" 两种 SSE 格式
@@ -193,11 +194,15 @@ class GrokSearchProvider(BaseSearchProvider):
                     choices = data.get("choices", [])
                     if choices and len(choices) > 0:
                         delta = choices[0].get("delta", {})
-                        if "content" in delta:
+                        if "content" in delta and delta["content"]:
                             content += delta["content"]
+                        # reasoning 模型（如 expert）会先输出 reasoning_content，
+                        # 作为无正文时的回退，避免返回空字符串。
+                        if "reasoning_content" in delta and delta["reasoning_content"]:
+                            reasoning += delta["reasoning_content"]
                 except (json.JSONDecodeError, IndexError):
                     continue
-                
+
         if not content and full_body_buffer:
             try:
                 full_text = "".join(full_body_buffer)
@@ -205,16 +210,21 @@ class GrokSearchProvider(BaseSearchProvider):
                 if "choices" in data and len(data["choices"]) > 0:
                     message = data["choices"][0].get("message", {})
                     content = message.get("content", "")
+                    if not content:
+                        reasoning = reasoning or message.get("reasoning_content", "")
             except json.JSONDecodeError:
                 pass
-        
+
+        if not content and reasoning:
+            content = reasoning
+
         await log_info(ctx, f"content: {content}", config.debug_enabled)
 
         return content
 
     async def _execute_stream_with_retry(self, headers: dict, payload: dict, ctx=None) -> str:
         """执行带重试机制的流式 HTTP 请求"""
-        timeout = httpx.Timeout(connect=6.0, read=120.0, write=10.0, pool=None)
+        timeout = httpx.Timeout(connect=config.connect_timeout, read=config.read_timeout, write=10.0, pool=None)
 
         async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
             async for attempt in AsyncRetrying(


### PR DESCRIPTION
## 问题

使用 reasoning 类模型（如 `grok-chat-expert`）作为搜索后端时，有两个问题导致搜索失败或返回空：

### 1. 读超时硬编码 120 秒

`providers/grok.py` 中 `timeout = httpx.Timeout(connect=6.0, read=120.0, ...)` 写死。

reasoning 模型带联网搜索时，会先进入较长的推理阶段（实测 expert + web search 约 85 秒才输出首个正文 chunk），推理耗时长的场景容易超过 120 秒，触发超时 → 重试 → 最终返回空结果。

### 2. `reasoning_content` 被忽略

`_parse_streaming_response` 只累加 `delta["content"]`。reasoning 模型的响应里大量 `reasoning_content` 被丢弃，如果某次响应只有推理内容、正文为空，解析结果就是空字符串。

## 修复

**config.py** — 新增两个环境变量：

| 变量 | 默认值 | 说明 |
|------|--------|------|
| `GROK_READ_TIMEOUT` | `300` | 流式读超时（秒），reasoning 模型建议调大 |
| `GROK_CONNECT_TIMEOUT` | `6` | 连接超时（秒） |

**providers/grok.py**：
- `_execute_stream_with_retry` 用 `config.read_timeout` / `config.connect_timeout` 替代硬编码
- `_parse_streaming_response` 累加 `reasoning_content`，当正文为空时回退用推理内容，避免空返回

## 兼容性

- 默认 300 秒对普通模型无副作用（正常几秒返回）
- 非 reasoning 模型无 `reasoning_content` 字段，回退逻辑不触发，行为不变